### PR TITLE
Replace infinite stream with one that finishes when all subjects are sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ Using Docker:
   * `docker-compose run web mix ecto.create`
   * `docker-compose run test mix test`
   * `docker-compose up` and `curl http://localhost:4000/api`
+
+Running a benchmark:
+
+  * First of all, compile a production-like version of the app, since the dev server will be doing code reloads and a whole bunch of other things:
+  * `MIX_ENV=bench PORT=4000 POSTGRES_USER=marten POSTGRES_HOST=localhost DESIGNATOR_AUTH_PASSWORD=foo elixir -pa _build/bench/consolidated -S mix phoenix.server`
+  * `brew install siege`
+  * `siege -d1 -c100 -t20s http://localhost:4000/api/workflows/338\?strategy\=weighted`

--- a/lib/designator/random.ex
+++ b/lib/designator/random.ex
@@ -21,6 +21,16 @@ defmodule Designator.Random do
     {index, element}
   end
 
+  def unique_element(enumerable, drawn) do
+    {index, element} = element(enumerable)
+
+    if MapSet.member?(drawn, index) do
+      unique_element(enumerable, drawn)
+    else
+      {index, element}
+    end
+  end
+
   def weighted(enumerable) do
     weights = Enum.map(enumerable, &elem(&1, 1))
     total   = Enum.sum(weights)

--- a/lib/designator/random_stream.ex
+++ b/lib/designator/random_stream.ex
@@ -1,0 +1,24 @@
+defmodule Designator.RandomStream do
+  alias Designator.Random
+
+  @spec shuffle(Enumerable.t) :: Enumerable.t
+  def shuffle(enum) do
+    Stream.unfold({enum, MapSet.new}, fn {enum, drawn} ->
+      if size(enum) <= MapSet.size(drawn) do
+        nil
+      else
+        {index, element} = Random.unique_element(enum, drawn)
+
+        {{index, element}, {enum, MapSet.put(drawn, index)}}
+      end
+    end)
+  end
+
+  defp size(enum = %Array{}) do
+    Array.size(enum)
+  end
+
+  defp size(enum) do
+    Enum.count(enum)
+  end
+end

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -12,7 +12,7 @@ defmodule Designator.Selection do
 
   defp do_select(streams, stream_amount, seen_subject_ids, amount, user) do
     seen_size = Enum.count(seen_subject_ids)
-    max_streamable = stream_amount - seen_size
+    max_streamable = stream_amount
     amount = min(max_streamable, amount)
 
     random_state = Process.get(:rand_seed)
@@ -26,7 +26,7 @@ defmodule Designator.Selection do
       |> reject_recently_retired
       |> reject_recently_selected(user)
       |> reject_seen_subjects(seen_subject_ids)
-      |> Enum.take(amount) # TODO: Breaks if not enough match
+      |> Enum.take(amount)
     end)
 
     case Task.yield(task, 1000) || Task.shutdown(task) do

--- a/lib/designator/subject_stream.ex
+++ b/lib/designator/subject_stream.ex
@@ -11,10 +11,7 @@ defmodule Designator.SubjectStream do
   ###
 
   defp build_stream(subject_ids) do
-    Stream.repeatedly fn ->
-      {_, element} = Designator.Random.element(subject_ids)
-      element
-    end
+    Designator.RandomStream.shuffle(subject_ids) |> Stream.map(fn {idx, elm} -> elm end)
   end
 
   def get_amount(%Array{} = subject_ids) do

--- a/lib/designator/subject_stream.ex
+++ b/lib/designator/subject_stream.ex
@@ -1,9 +1,7 @@
 defmodule Designator.SubjectStream do
   defstruct [:subject_set_id, :stream, :amount, :chance]
 
-  def build({subject_set_id, subject_ids}, configuration \\ %{}), do: build(subject_set_id, subject_ids, configuration)
-
-  def build(subject_set_id, subject_ids, configuration) do
+  def build(%{subject_set_id: subject_set_id, subject_ids: subject_ids}, configuration) do
     amount = get_amount(subject_ids)
     %Designator.SubjectStream{subject_set_id: subject_set_id, stream: build_stream(subject_ids), amount: amount, chance: amount * get_weight(subject_set_id, configuration)}
   end
@@ -11,7 +9,7 @@ defmodule Designator.SubjectStream do
   ###
 
   defp build_stream(subject_ids) do
-    Designator.RandomStream.shuffle(subject_ids) |> Stream.map(fn {idx, elm} -> elm end)
+    Designator.RandomStream.shuffle(subject_ids) |> Stream.map(fn {_idx, elm} -> elm end)
   end
 
   def get_amount(%Array{} = subject_ids) do

--- a/test/designator/random_stream_test.exs
+++ b/test/designator/random_stream_test.exs
@@ -4,6 +4,10 @@ defmodule Designator.RandomStreamTest do
   import Designator.RandomStream
 
   test "empty enum returns nothing" do
+    assert ([] |> shuffle |> Stream.take(5) |> Enum.sort) == []
+  end
+
+  test "returns data" do
     assert (1..5 |> shuffle |> Stream.take(5) |> Enum.sort) == [{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}]
   end
 end

--- a/test/designator/random_stream_test.exs
+++ b/test/designator/random_stream_test.exs
@@ -1,0 +1,9 @@
+defmodule Designator.RandomStreamTest do
+  use ExUnit.Case
+
+  import Designator.RandomStream
+
+  test "empty enum returns nothing" do
+    assert (1..5 |> shuffle |> Stream.take(5) |> Enum.sort) == [{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}]
+  end
+end

--- a/test/designator/random_test.exs
+++ b/test/designator/random_test.exs
@@ -22,4 +22,8 @@ defmodule Designator.RandomTest do
 
     assert indexes == [2, 5, 3, 1, 4, 4, 5, 0, 0, 5, 0, 0, 0, 0, 0, 4]
   end
+
+  test "get a random element without redrawing" do
+    assert Random.unique_element([1,2,3,4,5], MapSet.new([0,1,2,3])) == {4, 5}
+  end
 end

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -15,7 +15,7 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1682}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1682, subject_ids: Array.from_list([3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3])})
     SubjectSetCache.set({338, 1681}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1681, subject_ids: Array.from_list([4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4])})
 
-    assert Selection.select("weighted", 338, 1, 4) == [4, 3, 1, 2]
+    assert Selection.select("weighted", 338, 1, 4) == [4, 3, 2, 1]
   end
 
   test "weighed selection for normal sets" do


### PR DESCRIPTION
The SubjectStream now detects when it has sent out all subject_ids in the
set, and will signal an end-of-stream down the pipeline. This means that
reading 10 subjects from a stream that can only possibly emit 5, will finish
rather than hang forever.