### PR TITLE
Remove needless constant reloads for workflows

### DIFF
--- a/lib/designator/subject_set_cache.ex
+++ b/lib/designator/subject_set_cache.ex
@@ -35,15 +35,13 @@ defmodule Designator.SubjectSetCache do
   end
 
   def get({workflow_id, subject_set_id} = key) do
-    subject_set = ConCache.get_or_store(:subject_set_cache, key, fn() ->
+    ConCache.get_or_store(:subject_set_cache, key, fn() ->
       %__MODULE__{
         workflow_id: workflow_id,
         subject_set_id: subject_set_id,
         subject_ids: Array.new
       }
     end)
-
-    subject_set
   end
 
   def set(key, subject_set) do

--- a/lib/designator/subject_set_cache.ex
+++ b/lib/designator/subject_set_cache.ex
@@ -43,10 +43,6 @@ defmodule Designator.SubjectSetCache do
       }
     end)
 
-    if Array.size(subject_set.subject_ids) == 0 do
-      reload(key)
-    end
-
     subject_set
   end
 


### PR DESCRIPTION
This would keep reloading subject sets that have no subjects left. Originally intended as a safe-guard, but now that stuff expires, this is not needed.