### PR TITLE
Add per subject set selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Using Docker:
   * `docker-compose run test mix test`
   * `docker-compose up` and `curl http://localhost:4000/api`
 
+  Interactively debug the tests
+  ```
+  docker-compose run test bash`
+  iex -S mix test
+  mix test --only wip
+  ```
+
 Running a benchmark:
 
   * First of all, compile a production-like version of the app, since the dev server will be doing code reloads and a whole bunch of other things:

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -1,5 +1,5 @@
 defmodule Designator.Selection do
-  def select(_style, workflow_id, user_id, limit \\ 5) do
+  def select(_style, workflow_id, user_id, subject_set_id, limit \\ 5) do
     workflow = Designator.WorkflowCache.get(workflow_id)
     user = Designator.UserCache.get({workflow_id, user_id})
     seen_subject_ids = user.seen_ids

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -4,7 +4,7 @@ defmodule Designator.Selection do
     user = Designator.UserCache.get({workflow_id, user_id})
     seen_subject_ids = user.seen_ids
 
-    streams = get_streams(workflow, user)
+    streams = get_streams(workflow, user, subject_set_id)
     amount = Enum.sum(Enum.map(streams, fn stream -> stream.amount end))
 
     do_select(streams, amount, seen_subject_ids, limit, workflow, user)
@@ -43,8 +43,8 @@ defmodule Designator.Selection do
     end
   end
 
-  def get_streams(workflow, user) do
-    workflow.subject_set_ids
+  def get_streams(workflow, user, subject_set_id) do
+    selection_subject_set_ids(workflow.subject_set_ids, subject_set_id)
     |> get_subject_set_from_cache(workflow)
     |> reject_empty_sets
     |> convert_to_streams(workflow)
@@ -86,5 +86,13 @@ defmodule Designator.Selection do
 
   defp reject_seen_subjects(stream, seen_subject_ids) do
     Stream.reject(stream, fn x -> MapSet.member?(seen_subject_ids, x) end)
+  end
+
+  defp selection_subject_set_ids(all_subject_set_ids, subject_set_id) do
+    if Enum.member?(all_subject_set_ids, subject_set_id) do
+      [ subject_set_id ]
+    else
+      all_subject_set_ids
+    end
   end
 end

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -1,13 +1,15 @@
 defmodule Designator.Selection do
-  def select(_style, workflow_id, user_id, subject_set_id, limit \\ 5) do
+  def select(_style, workflow_id, user_id, options \\ []) do
+    selection_options = options_with_defaults(options)
+
     workflow = Designator.WorkflowCache.get(workflow_id)
     user = Designator.UserCache.get({workflow_id, user_id})
     seen_subject_ids = user.seen_ids
 
-    streams = get_streams(workflow, user, subject_set_id)
+    streams = get_streams(workflow, user, selection_options.subject_set_id)
     amount = Enum.sum(Enum.map(streams, fn stream -> stream.amount end))
 
-    do_select(streams, amount, seen_subject_ids, limit, workflow, user)
+    do_select(streams, amount, seen_subject_ids, selection_options.limit, workflow, user)
   end
 
   defp do_select(streams, stream_amount, seen_subject_ids, amount, workflow, user) do
@@ -94,5 +96,10 @@ defmodule Designator.Selection do
     else
       all_subject_set_ids
     end
+  end
+
+  defp options_with_defaults(options) do
+    defaults = [subject_set_id: nil, limit: 5]
+    Keyword.merge(defaults, options) |> Enum.into(%{})
   end
 end

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -15,7 +15,7 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1682}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1682, subject_ids: Array.from_list([3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3])})
     SubjectSetCache.set({338, 1681}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1681, subject_ids: Array.from_list([4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4])})
 
-    assert Selection.select("weighted", 338, 1, 4) == [4, 2, 1, 3]
+    assert Selection.select("weighted", 338, 1, [limit: 4]) == [4, 2, 1, 3]
   end
 
   test "spacewarps weighting" do
@@ -27,7 +27,7 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1682}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1682, subject_ids: Array.from_list([3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3])})
     SubjectSetCache.set({338, 1681}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1681, subject_ids: Array.from_list([4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4])})
 
-    assert Selection.select("weighted", 338, 1, 4) == [4, 2, 3, 1]
+    assert Selection.select("weighted", 338, 1, [limit: 4]) == [4, 2, 3, 1]
   end
 
   test "weighed selection for normal sets" do
@@ -42,7 +42,7 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1002}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1002, subject_ids: Array.from_list([5])})
     SubjectSetCache.set({338, 1003}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1003, subject_ids: Array.from_list([6])})
 
-    assert Selection.select("weighted", 338, 1, 6) == [4, 5, 1, 2, 3, 6]
+    assert Selection.select("weighted", 338, 1, [limit: 6]) == [4, 5, 1, 2, 3, 6]
   end
 
   @tag timeout: 1000
@@ -58,7 +58,7 @@ defmodule Designator.SelectionTest do
 
     assert Designator.UserCache.get({338, 1}).seen_ids == MapSet.new([1,2,3,4])
 
-    assert Selection.select("weighted", 338, 1, 4) == []
+    assert Selection.select("weighted", 338, 1) == []
   end
 
   test "selects subjects from a supplied subject_set_id" do
@@ -67,7 +67,7 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
     SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
 
-    assert Selection.select("weighted", 338, 1, 681, 2) == [1]
+    assert Selection.select("weighted", 338, 1, [subject_set_id: 681, limit: 2]) == [1]
   end
 
   test "does not select recently handed out subject ids" do
@@ -79,8 +79,8 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1682}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1682, subject_ids: Array.from_list([3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3])})
     SubjectSetCache.set({338, 1681}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1681, subject_ids: Array.from_list([4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4])})
 
-    Selection.select("weighted", 338, 1, 4)
-    assert Selection.select("weighted", 338, 1, 4) == []
+    run_selection_to_setup_cache = Selection.select("weighted", 338, 1, [limit: 4])
+    assert Selection.select("weighted", 338, 1, [limit: 4]) == []
   end
 
   test "does not select recently retired subject ids" do
@@ -92,12 +92,12 @@ defmodule Designator.SelectionTest do
     Designator.RecentlyRetired.add(338, 2)
     Designator.RecentlyRetired.add(338, 3)
 
-    assert Selection.select("weighted", 338, 1, 4) == [4]
+    assert Selection.select("weighted", 338, 1, [limit: 4]) == [4]
   end
 
   test "workflow that does not exist" do
-    assert Selection.select("uniform", 404, 1, 4) == []
-    assert Selection.select("weighted", 404, 1, 4) == []
+    assert Selection.select("uniform", 404, 1) == []
+    assert Selection.select("weighted", 404, 1) == []
   end
 
   test "empty subject set" do
@@ -109,6 +109,6 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1682},%SubjectSetCache{workflow_id: 338, subject_set_id: 1002, subject_ids: Array.from_list([3])})
     SubjectSetCache.set({338, 1681},%SubjectSetCache{workflow_id: 338, subject_set_id: 1003, subject_ids: Array.from_list([4])})
 
-    assert Selection.select("weighted", 338, 1, 2) == [4, 3]
+    assert Selection.select("weighted", 338, 1, [limit: 2]) == [4, 3]
   end
 end

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -61,14 +61,13 @@ defmodule Designator.SelectionTest do
     assert Selection.select("weighted", 338, 1, 4) == []
   end
 
-  @tag :wip
   test "selects subjects from a supplied subject_set_id" do
     Designator.Random.seed({123, 123534, 345345})
     Designator.WorkflowCache.set(338, %{ configuration: %{}, subject_set_ids: [681, 1706]})
     SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
     SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
 
-    assert Selection.select("weighted", 338, 1, 4, 681) == [1]
+    assert Selection.select("weighted", 338, 1, 681, 2) == [1]
   end
 
   test "does not select recently handed out subject ids" do

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -70,6 +70,15 @@ defmodule Designator.SelectionTest do
     assert Selection.select("weighted", 338, 1, [subject_set_id: 681, limit: 2]) == [1]
   end
 
+  test "selects subjects from all subject sets if an unknown subject_set_id" do
+    Designator.Random.seed({123, 123534, 345345})
+    Designator.WorkflowCache.set(338, %{ configuration: %{}, subject_set_ids: [681, 1706]})
+    SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
+    SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
+
+    assert Selection.select("weighted", 338, 1, [subject_set_id: 1, limit: 2]) == [2,1]
+  end
+
   test "does not select recently handed out subject ids" do
     Designator.Random.seed({123, 123534, 345345})
     Designator.WorkflowCache.set(338, %{configuration: %{"gold_standard_sets" => [681, 1706]},

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -61,6 +61,16 @@ defmodule Designator.SelectionTest do
     assert Selection.select("weighted", 338, 1, 4) == []
   end
 
+  @tag :wip
+  test "selects subjects from a supplied subject_set_id" do
+    Designator.Random.seed({123, 123534, 345345})
+    Designator.WorkflowCache.set(338, %{ configuration: %{}, subject_set_ids: [681, 1706]})
+    SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
+    SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
+
+    assert Selection.select("weighted", 338, 1, 4, 681) == [1]
+  end
+
   test "does not select recently handed out subject ids" do
     Designator.Random.seed({123, 123534, 345345})
     Designator.WorkflowCache.set(338, %{configuration: %{"gold_standard_sets" => [681, 1706]},

--- a/web/controllers/workflow_controller.ex
+++ b/web/controllers/workflow_controller.ex
@@ -7,9 +7,15 @@ defmodule Designator.WorkflowController do
     {workflow_id, _} = Integer.parse(workflow_id)
     user_id = get_integer_param(params, "user_id", nil)
     strategy = Map.get(params, "strategy", "uniform")
+    subject_set_id = get_integer_param(params, "subject_set_id", nil)
     limit = get_integer_param(params, "limit", 5)
 
-    subjects = Designator.Selection.select(strategy, workflow_id, user_id, limit)
+    subjects = Designator.Selection.select(
+      strategy,
+      workflow_id,
+      user_id,
+      [ subject_set_id: subject_set_id, limit: limit ]
+    )
     Logger.metadata([selected_ids: Enum.join(subjects, ",")])
     render conn, "show.json", subjects: subjects
   end


### PR DESCRIPTION
Allow the API to accept a `subject_set_id` query param and filter restrict the selected subject to the subject set matching the param, if valid for this workflow.