### PR TITLE
Add API to allow updates to a user's seen subject ids for a workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+deps/*
+_build/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Editor artifacts
 /.elixir_ls
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Using Docker:
   * `docker-compose down --rmi all -v --remove-orphans`
   * `docker-compose build`
   * `docker-compose run web mix ecto.create`
+  * `docker-compose run test mix deps.get`
   * `docker-compose run test mix test`
   * `docker-compose up` and `curl http://localhost:4000/api`
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Using Docker:
 
   * `docker-compose down --rmi all -v --remove-orphans`
   * `docker-compose build`
-  * `docker-compose run web mix ecto.create`
-  * `docker-compose run test mix deps.get`
-  * `docker-compose run test mix test`
+  * `docker-compose run --rm web mix ecto.create`
+  * `docker-compose run --rm test mix deps.get`
+  * `docker-compose run --rm test mix test`
   * `docker-compose up` and `curl http://localhost:4000/api`
 
   Interactively debug the tests
   ```
-  docker-compose run test bash
+  docker-compose run --rm test bash
   iex -S mix test --trace
   mix test --only wip
   ```

--- a/lib/designator/user_cache.ex
+++ b/lib/designator/user_cache.ex
@@ -71,6 +71,7 @@ defmodule Designator.UserCache do
     end)
   end
 
+  def add_recently_selected(%{workflow_id: workflow_id, user_id: user_id}, subject_ids), do: add_recently_selected({workflow_id, user_id}, subject_ids)
   def add_recently_selected({_, nil}, _), do: :ok
   def add_recently_selected(key, subject_ids) do
     ConCache.update_existing(:user_cache, key, fn (user) ->

--- a/lib/designator/user_cache.ex
+++ b/lib/designator/user_cache.ex
@@ -71,13 +71,21 @@ defmodule Designator.UserCache do
     end)
   end
 
-  def add_recently_selected(%{workflow_id: workflow_id, user_id: user_id}, subject_ids), do: add_recently_selected({workflow_id, user_id}, subject_ids)
   def add_recently_selected({_, nil}, _), do: :ok
   def add_recently_selected(key, subject_ids) do
     ConCache.update_existing(:user_cache, key, fn (user) ->
       recently_selected_ids = MapSet.union(user.recently_selected_ids, MapSet.new(subject_ids))
 
       {:ok, %__MODULE__{user | recently_selected_ids: recently_selected_ids}}
+    end)
+  end
+
+  def add_seen_ids({_, nil}, _), do: :ok
+  def add_seen_ids(key, subject_ids) do
+    ConCache.update_existing(:user_cache, key, fn (user) ->
+      recently_seen_ids = MapSet.union(user.seen_ids, MapSet.new(subject_ids))
+
+      {:ok, %__MODULE__{user | seen_ids: recently_seen_ids}}
     end)
   end
 end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -74,10 +74,10 @@ defmodule Designator.UserControllerTest do
       assert user.seen_ids == MapSet.new([3,2,1])
     end
 
-    test "adds the subject ids when using the subject_id param", %{user: user, workflow_id: workflow_id, conn: conn} do
+    test "adds the subject id when using the subject_id param", %{user: user, workflow_id: workflow_id, conn: conn} do
       conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_id: 1432)
+      |> put("/api/users/#{user.user_id}/add_seen_subject", workflow_id: workflow_id, subject_id: 1432)
       assert response(conn_response, 204) == ""
       user = Designator.UserCache.get({workflow_id, user.user_id})
       assert user.seen_ids == MapSet.new([1432])

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -118,5 +118,20 @@ defmodule Designator.UserControllerTest do
       user = Designator.UserCache.get({workflow_id, user.user_id})
       assert user.seen_ids == MapSet.new([4,5,6,7])
     end
+
+    test "ensure an ordered distinct union of existing and incoming subject ids", %{user: user, workflow_id: workflow_id, conn: conn} do
+      Designator.UserCache.set(
+        { workflow_id, user.user_id },
+        %{
+          seen_ids: MapSet.new([1,2,3]),
+          recently_selected_ids: MapSet.new,
+          configuration: %{}
+        }
+      )
+      conn_response = put_req(conn, user.user_id, workflow_id, [6,4,5])
+      assert response(conn_response, 204) == ""
+      user = Designator.UserCache.get({workflow_id, user.user_id})
+      assert user.seen_ids == MapSet.new([1,2,3,4,5,6])
+    end
   end
 end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -92,7 +92,7 @@ defmodule Designator.UserControllerTest do
     test "rejects non integer subject id", %{user: user, workflow_id: workflow_id, conn: conn} do
       conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_id: "test")
+      |> put("/api/users/#{user.user_id}/add_seen_subject", workflow_id: workflow_id, subject_id: "test")
       four_twenty_two = json_response(conn_response, 422)
       assert four_twenty_two["errors"] == "invalid subject id supplied, must be a valid integer"
     end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -1,0 +1,100 @@
+defmodule Designator.UserControllerTest do
+  use Designator.ConnCase
+
+  @username Application.fetch_env!(:designator, :api_auth)[:username]
+  @password Application.fetch_env!(:designator, :api_auth)[:password]
+
+  alias Designator.User
+
+  setup %{conn: conn} do
+    workflow_id =  1
+    user_id = 2
+    {
+      :ok,
+      [
+        user: Designator.UserCache.get({workflow_id, user_id}),
+        workflow_id: workflow_id,
+        conn: put_req_header(conn, "accept", "application/json")
+      ]
+    }
+  end
+
+
+  # PUT /users/:user_id/add_seen_subjects?workflow_id=X&subject_ids=1,2,3,4
+  describe "adding a known user seen subjects for a workflow" do
+    test "requires authentication", %{user: user, workflow_id: workflow_id, conn: conn} do
+      conn_response = conn
+      |> post(user_path(conn, :add_seen_subjects, user, workflow_id: workflow_id, subject_ids: '1'))
+      assert response(conn_response, 401) == "401 Unauthorized"
+    end
+
+    test "respons with a 201 created response code", %{user: user, workflow_id: workflow_id, conn: conn} do
+      conn_response = conn
+      |> http_basic_authenticate(@username, @password)
+      |> put(user_path(conn, :add_seen_subjects, worklfow_id: workflow_id, subject_ids: '1'))
+      assert response(conn_response, 201) == ""
+    end
+
+    test "respons with a 204 no-content response code for loaded users", %{user: user, workflow_id: workflow_id, conn: conn} do
+      Designator.UserCache.set(
+        { workflow_id, user.id },
+        %{
+          seen_ids: MapSet.new([1]),
+          recently_selected_ids: MapSet.new,
+          configuration: %{}
+        }
+      )
+      conn_response = conn
+      |> http_basic_authenticate(@username, @password)
+      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '1'))
+      assert response(conn_response, 204) == ""
+    end
+
+    test "adds the subject ids", %{user: user, workflow_id: workflow_id, conn: conn} do
+      conn_response = conn
+      |> http_basic_authenticate(@username, @password)
+      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '1'))
+      assert response(conn_response, 201) == ""
+      user = Designator.UserCache.get({workflow_id, user_id})
+      assert user.seen_ids == MapSet.new([1])
+    end
+
+    test "adds the subject ids when using the subject_id param", %{user: user, workflow_id: workflow_id, conn: conn} do
+      conn_response = conn
+      |> http_basic_authenticate(@username, @password)
+      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_id: '1,2,3'))
+      assert response(conn_response, 201) == ""
+      user = Designator.UserCache.get({workflow_id, user_id})
+      assert user.seen_ids == MapSet.new([1,2,3])
+    end
+
+    test "adds subject ids listed as comma delimited string", %{user: user, workflow_id: workflow_id, conn: conn} do
+      conn = conn
+      |> http_basic_authenticate(@username, @password)
+      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '1,2,3'))
+      assert response(conn, 201) == ""
+      user = Designator.UserCache.get({workflow_id, user_id})
+      assert user.seen_ids == MapSet.new([1,2,3])
+    end
+
+    test "does not duplicate subject ids", %{user: user, workflow_id: workflow_id, conn: conn} do
+      Designator.UserCache.set(
+        { workflow_id, user.id },
+        %{
+          seen_ids: MapSet.new([5,6]),
+          recently_selected_ids: MapSet.new,
+          configuration: %{}
+        }
+      )
+      conn = conn
+      |> http_basic_authenticate(@username, @password)
+      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '5,6,7,4'))
+      assert response(conn_response, 204) == ""
+      assert user.seen_ids == MapSet.new([4,5,6,7])
+    end
+  end
+
+  def http_basic_authenticate(conn, username, password) do
+    put_req_header(conn, "authorization", "Basic " <> Base.encode64(username <> ":" <> password))
+  end
+end

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -97,6 +97,13 @@ defmodule Designator.UserControllerTest do
       assert four_twenty_two["errors"] == "invalid subject id supplied, must be a valid integer"
     end
 
+    test "casts the subject_ids to ints before storing", %{user: user, workflow_id: workflow_id, conn: conn} do
+      conn_response = put_req(conn, user.user_id, workflow_id, [3,"2",1])
+      assert response(conn_response, 204) == ""
+      user = Designator.UserCache.get({workflow_id, user.user_id})
+      assert user.seen_ids == MapSet.new([3,2,1])
+    end
+
     test "does de-duplicate the incoming subject ids", %{user: user, workflow_id: workflow_id, conn: conn} do
       Designator.UserCache.set(
         { workflow_id, user.user_id },

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -53,12 +53,12 @@ defmodule Designator.UserControllerTest do
       assert response(conn_response, 401) == "401 Unauthorized"
     end
 
-    test "respons with a 201 created response code for an not loaded users", %{workflow_id: workflow_id, conn: conn} do
+    test "responds with a 201 created response code for an not loaded users", %{workflow_id: workflow_id, conn: conn} do
       conn_response = put_req(conn, "99", workflow_id, [1])
       assert response(conn_response, 201) == ""
     end
 
-    test "respons with a 204 no-content response code for loaded users", %{user: user, workflow_id: workflow_id, conn: conn} do
+    test "responds with a 204 no-content response code for loaded users", %{user: user, workflow_id: workflow_id, conn: conn} do
       Designator.UserCache.set(
         { workflow_id, user.user_id },
         %{seen_ids: MapSet.new([9])}

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -20,7 +20,7 @@ defmodule Designator.UserControllerTest do
   end
 
   def add_seens_path(user_id) do
-    "/users/#{:user_id}/add_seen_subjects"
+    "/api/users/#{:user_id}/add_seen_subjects"
   end
 
   def http_basic_authenticate(conn, username, password) do

--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -19,25 +19,32 @@ defmodule Designator.UserControllerTest do
     }
   end
 
+  def add_seens_path(user_id) do
+    "/users/#{:user_id}/add_seen_subjects"
+  end
 
-  # PUT /users/:user_id/add_seen_subjects?workflow_id=X&subject_ids=1,2,3,4
+  def http_basic_authenticate(conn, username, password) do
+    put_req_header(conn, "authorization", "Basic " <> Base.encode64(username <> ":" <> password))
+  end
+
+  @tag :wip
   describe "adding a known user seen subjects for a workflow" do
     test "requires authentication", %{user: user, workflow_id: workflow_id, conn: conn} do
       conn_response = conn
-      |> post(user_path(conn, :add_seen_subjects, user, workflow_id: workflow_id, subject_ids: '1'))
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_ids: '1')
       assert response(conn_response, 401) == "401 Unauthorized"
     end
 
     test "respons with a 201 created response code", %{user: user, workflow_id: workflow_id, conn: conn} do
       conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(user_path(conn, :add_seen_subjects, worklfow_id: workflow_id, subject_ids: '1'))
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_ids: '1')
       assert response(conn_response, 201) == ""
     end
 
     test "respons with a 204 no-content response code for loaded users", %{user: user, workflow_id: workflow_id, conn: conn} do
       Designator.UserCache.set(
-        { workflow_id, user.id },
+        { workflow_id, user.user_id },
         %{
           seen_ids: MapSet.new([1]),
           recently_selected_ids: MapSet.new,
@@ -46,55 +53,51 @@ defmodule Designator.UserControllerTest do
       )
       conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '1'))
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_ids: '1')
       assert response(conn_response, 204) == ""
     end
 
     test "adds the subject ids", %{user: user, workflow_id: workflow_id, conn: conn} do
       conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '1'))
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_ids: '1')
       assert response(conn_response, 201) == ""
-      user = Designator.UserCache.get({workflow_id, user_id})
+      user = Designator.UserCache.get({workflow_id, user.user_id})
       assert user.seen_ids == MapSet.new([1])
     end
 
     test "adds the subject ids when using the subject_id param", %{user: user, workflow_id: workflow_id, conn: conn} do
       conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_id: '1,2,3'))
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_id: '1,2,3')
       assert response(conn_response, 201) == ""
-      user = Designator.UserCache.get({workflow_id, user_id})
+      user = Designator.UserCache.get({workflow_id, user.user_id})
       assert user.seen_ids == MapSet.new([1,2,3])
     end
 
     test "adds subject ids listed as comma delimited string", %{user: user, workflow_id: workflow_id, conn: conn} do
-      conn = conn
+      conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '1,2,3'))
-      assert response(conn, 201) == ""
-      user = Designator.UserCache.get({workflow_id, user_id})
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_ids: '1,2,3')
+      assert response(conn_response, 201) == ""
+      user = Designator.UserCache.get({workflow_id, user.user_id})
       assert user.seen_ids == MapSet.new([1,2,3])
     end
 
     test "does not duplicate subject ids", %{user: user, workflow_id: workflow_id, conn: conn} do
       Designator.UserCache.set(
-        { workflow_id, user.id },
+        { workflow_id, user.user_id },
         %{
           seen_ids: MapSet.new([5,6]),
           recently_selected_ids: MapSet.new,
           configuration: %{}
         }
       )
-      conn = conn
+      conn_response = conn
       |> http_basic_authenticate(@username, @password)
-      |> put(user_path(conn, :add_seen_subjects, workflow_id: workflow_id, subject_ids: '5,6,7,4'))
+      |> put(add_seens_path(user.user_id), workflow_id: workflow_id, subject_ids: '5,6,7,4')
       assert response(conn_response, 204) == ""
       assert user.seen_ids == MapSet.new([4,5,6,7])
     end
-  end
-
-  def http_basic_authenticate(conn, username, password) do
-    put_req_header(conn, "authorization", "Basic " <> Base.encode64(username <> ":" <> password))
   end
 end

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -103,7 +103,7 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1682}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1682, subject_ids: Array.from_list([3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3])})
     SubjectSetCache.set({338, 1681}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1681, subject_ids: Array.from_list([4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4])})
 
-    run_selection_to_setup_cache = Selection.select(338, 1, [limit: 4])
+    _run_selection_to_setup_cache = Selection.select(338, 1, [limit: 4])
     assert Selection.select(338, 1, [limit: 4]) == []
   end
 

--- a/web/controllers/helpers.ex
+++ b/web/controllers/helpers.ex
@@ -17,4 +17,13 @@ defmodule Designator.Controllers.Helpers do
       |> Plug.Conn.halt
     end
   end
+
+  defp get_integer_param(params, key, default) do
+    case Map.get(params, key) do
+      nil -> default
+      value ->
+        {int, _} = Integer.parse(value)
+        int
+    end
+  end
 end

--- a/web/controllers/helpers.ex
+++ b/web/controllers/helpers.ex
@@ -1,9 +1,15 @@
 defmodule Designator.Controllers.Helpers do
+
+  defmodule InvalidInteger do
+    defexception [:message]
+  end
+
   import Plug.Conn
 
-  def render_blank(conn) do
+  def render_json_response(conn, code, body) do
     conn
-    |> send_resp(204, "")
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(code, body)
   end
 
   def authenticate(conn, username, password) do
@@ -30,8 +36,11 @@ defmodule Designator.Controllers.Helpers do
   end
 
   def convert_to_int(value) when is_binary(value) do
-    {int_value, _} = Integer.parse(value)
-    int_value
+
+    case Integer.parse(value) do
+      :error -> raise %InvalidInteger{message: "invalid integer value"}
+      {int_value, _} -> int_value
+    end
   end
 
   def convert_to_int(value) when is_list(value) do

--- a/web/controllers/helpers.ex
+++ b/web/controllers/helpers.ex
@@ -1,0 +1,20 @@
+defmodule Designator.Controllers.Helpers do
+  import Plug.Conn
+
+  def render_blank(conn) do
+    conn
+    |> send_resp(204, "")
+  end
+
+  def authenticate(conn, username, password) do
+    desired_username = Application.fetch_env!(:designator, :api_auth)[:username]
+    desired_password = Application.fetch_env!(:designator, :api_auth)[:password]
+
+    if username == desired_username && password == desired_password do
+      conn
+    else
+      conn
+      |> Plug.Conn.halt
+    end
+  end
+end

--- a/web/controllers/helpers.ex
+++ b/web/controllers/helpers.ex
@@ -18,12 +18,24 @@ defmodule Designator.Controllers.Helpers do
     end
   end
 
-  defp get_integer_param(params, key, default) do
+  def get_integer_param(params, key, default) do
     case Map.get(params, key) do
       nil -> default
-      value ->
-        {int, _} = Integer.parse(value)
-        int
+      value -> convert_to_int(value)
     end
+  end
+
+  def convert_to_int(value) when is_integer(value) do
+    value
+  end
+
+  def convert_to_int(value) when is_binary(value) do
+    {int_value, _} = Integer.parse(value)
+    int_value
+  end
+
+  def convert_to_int(value) when is_list(value) do
+    {int_value, _} = Integer.parse(to_string(value))
+    int_value
   end
 end

--- a/web/controllers/helpers.ex
+++ b/web/controllers/helpers.ex
@@ -1,9 +1,4 @@
 defmodule Designator.Controllers.Helpers do
-
-  defmodule InvalidInteger do
-    defexception [:message]
-  end
-
   import Plug.Conn
 
   def render_json_response(conn, code, body) do
@@ -36,15 +31,16 @@ defmodule Designator.Controllers.Helpers do
   end
 
   def convert_to_int(value) when is_binary(value) do
-
     case Integer.parse(value) do
-      :error -> raise %InvalidInteger{message: "invalid integer value"}
+      :error -> :error
       {int_value, _} -> int_value
     end
   end
 
-  def convert_to_int(value) when is_list(value) do
-    {int_value, _} = Integer.parse(to_string(value))
-    int_value
+  def is_invalid_integer(value) do
+    case value do
+      :error -> true
+      _  -> false
+    end
   end
 end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -21,19 +21,17 @@ defmodule Designator.UserController do
     {workflow_id, user_id}
   end
 
-  defp process_request(workflow_id, user_id, subject_ids) do
-    cache_key = user_cache_key(workflow_id, user_id)
-    # ensure the subject ids are all valid integers
-    try do
-      subject_ids = subject_ids
+  def process_request(workflow_id, user_id, subject_ids) do
+    cast_subject_ids = subject_ids
       |> Enum.map(&(convert_to_int(&1)))
 
-      # attempt to add to the user cache seen_ids store
-      response_code = add_subject_ids_to_seens(cache_key, subject_ids)
+    invalid_integer_params = Enum.any?(cast_subject_ids, &is_invalid_integer(&1))
+    if invalid_integer_params do
+      { 422, Poison.encode!(%{errors: "invalid subject id supplied, must be a valid integer"}) }
+    else
+      cache_key = user_cache_key(workflow_id, user_id)
+      response_code = add_subject_ids_to_seens(cache_key, cast_subject_ids)
       { response_code, [] }
-    rescue
-      Designator.Controllers.Helpers.InvalidInteger ->
-        { 422, Poison.encode!(%{errors: "invalid subject id supplied, must be a valid integer"}) }
     end
   end
 

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -25,7 +25,7 @@ defmodule Designator.UserController do
     cache_key = user_cache_key(workflow_id, user_id)
     # ensure the subject ids are all valid integers
     try do
-      subject_ids
+      subject_ids = subject_ids
       |> Enum.map(&(convert_to_int(&1)))
 
       # attempt to add to the user cache seen_ids store

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -13,11 +13,10 @@ defmodule Designator.UserController do
     # {subject_ids, _} = subject_ids
     # |> Enum.map(&(Integer.parse(&1)))
     # require IEx; IEx.pry
-    # Designator.UserCache.get(user_cache_key)
 
     response_code =
       case Designator.UserCache.add_seen_ids(user_cache_key, subject_ids) do
-        {:error, :not_existing} -> # user not loaded, ignoring
+        {:error, :not_existing} -> # user not loaded ignore
           201
         :ok -> # update the existing user data
           204

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -1,0 +1,9 @@
+defmodule Designator.UserController do
+  use Designator.Web, :controller
+
+  plug BasicAuth, [callback: &Designator.Controllers.Helpers.authenticate/3] when action in [:add_seen_subjects]
+
+  def add_seen_subjects(conn, %{"id" => user_id, "subject_ids" => subject_ids}) do
+    render_blank(conn)
+  end
+end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -4,25 +4,44 @@ defmodule Designator.UserController do
   plug BasicAuth, [callback: &Designator.Controllers.Helpers.authenticate/3] when action in [:add_seen_subjects]
 
   def add_seen_subjects(conn, %{"id" => user_id, "workflow_id" => workflow_id, "subject_ids" => subject_ids}) do
+    { response_code, body} = process_request(user_cache_key(user_id, workflow_id), subject_ids)
+
+    render_json_response(conn, response_code, body)
+  end
+
+  def add_seen_subjects(conn, %{"id" => user_id, "workflow_id" => workflow_id, "subject_id" => subject_id}) do
+    { response_code, body} = process_request(user_cache_key(user_id, workflow_id), [subject_id])
+
+    render_json_response(conn, response_code, body)
+  end
+
+  defp user_cache_key(user_id, workflow_id) do
     user_id = convert_to_int(user_id)
     workflow_id = convert_to_int(workflow_id)
-    user_cache_key = {workflow_id, user_id}
     {workflow_id, user_id}
+  end
 
-    # TODO: do we have to ensure a list of subject id ints?
-    # {subject_ids, _} = subject_ids
-    # |> Enum.map(&(Integer.parse(&1)))
-    # require IEx; IEx.pry
+  defp process_request(user_cache_key, subject_ids) do
+    # ensure the subject ids are all valid integers and
+    try do
+      subject_ids
+      |> Enum.map(&(convert_to_int(&1)))
 
-    response_code =
-      case Designator.UserCache.add_seen_ids(user_cache_key, subject_ids) do
-        {:error, :not_existing} -> # user not loaded ignore
-          201
-        :ok -> # update the existing user data
-          204
-      end
+      # attempt to add to the user cache seen_ids store
+      response_code = add_subject_ids_to_seens(user_cache_key, subject_ids)
+      { response_code, [] }
+    rescue
+      Designator.Controllers.Helpers.InvalidInteger ->
+        { 422, Poison.encode!(%{errors: "invalid subject id supplied, must be a valid integer"}) }
+    end
+  end
 
-    conn
-    |> send_resp(response_code, "")
+  defp add_subject_ids_to_seens(user_cache_key, subject_ids) do
+    case Designator.UserCache.add_seen_ids(user_cache_key, subject_ids) do
+      {:error, :not_existing} -> # user not loaded ignore the incoming request
+        201
+      :ok -> # update the existing user data
+        204
+    end
   end
 end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -9,7 +9,7 @@ defmodule Designator.UserController do
     render_json_response(conn, response_code, body)
   end
 
-  def add_seen_subjects(conn, %{"id" => user_id, "workflow_id" => workflow_id, "subject_id" => subject_id}) do
+  def add_seen_subject(conn, %{"id" => user_id, "workflow_id" => workflow_id, "subject_id" => subject_id}) do
     { response_code, body} = process_request(workflow_id, user_id, [subject_id])
 
     render_json_response(conn, response_code, body)

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -3,7 +3,27 @@ defmodule Designator.UserController do
 
   plug BasicAuth, [callback: &Designator.Controllers.Helpers.authenticate/3] when action in [:add_seen_subjects]
 
-  def add_seen_subjects(conn, %{"id" => user_id, "subject_ids" => subject_ids}) do
-    render_blank(conn)
+  def add_seen_subjects(conn, %{"id" => user_id, "workflow_id" => workflow_id, "subject_ids" => subject_ids}) do
+    user_id = convert_to_int(user_id)
+    workflow_id = convert_to_int(workflow_id)
+    user_cache_key = {workflow_id, user_id}
+    {workflow_id, user_id}
+
+    # TODO: do we have to ensure a list of subject id ints?
+    # {subject_ids, _} = subject_ids
+    # |> Enum.map(&(Integer.parse(&1)))
+    # require IEx; IEx.pry
+    # Designator.UserCache.get(user_cache_key)
+
+    response_code =
+      case Designator.UserCache.add_seen_ids(user_cache_key, subject_ids) do
+        {:error, :not_existing} -> # user not loaded, ignoring
+          201
+        :ok -> # update the existing user data
+          204
+      end
+
+    conn
+    |> send_resp(response_code, "")
   end
 end

--- a/web/controllers/workflow_controller.ex
+++ b/web/controllers/workflow_controller.ex
@@ -56,15 +56,6 @@ defmodule Designator.WorkflowController do
     send_resp(conn, 204, [])
   end
 
-  defp get_integer_param(params, key, default) do
-    case Map.get(params, key) do
-      nil -> default
-      value ->
-        {int, _} = Integer.parse(value)
-        int
-    end
-  end
-
   defp do_full_reload(workflow_id) do
     Designator.RecentlyRetired.clear(workflow_id)
     Designator.WorkflowCache.reload(workflow_id)

--- a/web/controllers/workflow_controller.ex
+++ b/web/controllers/workflow_controller.ex
@@ -1,7 +1,7 @@
 defmodule Designator.WorkflowController do
   use Designator.Web, :controller
 
-  plug BasicAuth, [callback: &Designator.WorkflowController.authenticate/3] when action in [:reload, :unlock, :remove]
+  plug BasicAuth, [callback: &Designator.Controllers.Helpers.authenticate/3] when action in [:reload, :unlock, :remove]
 
   def show(conn, %{"id" => workflow_id} = params) do
     {workflow_id, _} = Integer.parse(workflow_id)
@@ -70,17 +70,5 @@ defmodule Designator.WorkflowController do
     Designator.WorkflowCache.reload(workflow_id)
     Designator.WorkflowCache.get(workflow_id).subject_set_ids
     |> Enum.each(fn subject_set_id -> Designator.SubjectSetCache.reload({workflow_id, subject_set_id}) end)
-  end
-
-  def authenticate(conn, username, password) do
-    desired_username = Application.fetch_env!(:designator, :api_auth)[:username]
-    desired_password = Application.fetch_env!(:designator, :api_auth)[:password]
-
-    if username == desired_username && password == desired_password do
-      conn
-    else
-      conn
-      |> Plug.Conn.halt
-    end
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -15,6 +15,8 @@ defmodule Designator.Router do
     post "/workflows/:id/reload", WorkflowController, :reload
     post "/workflows/:id/unlock", WorkflowController, :unlock
     post "/workflows/:id/remove", WorkflowController, :remove
+
+    put "/users/:id/add_seen_subjects", UserController, :add_seen_subjects
   end
 
   defp handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -17,6 +17,7 @@ defmodule Designator.Router do
     post "/workflows/:id/remove", WorkflowController, :remove
 
     put "/users/:id/add_seen_subjects", UserController, :add_seen_subjects
+    put "/users/:id/add_seen_subject", UserController, :add_seen_subject
   end
 
   defp handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do

--- a/web/web.ex
+++ b/web/web.ex
@@ -36,6 +36,7 @@ defmodule Designator.Web do
 
       import Designator.Router.Helpers
       import Designator.Gettext
+      import Designator.Controllers.Helpers
     end
   end
 


### PR DESCRIPTION
Closes #85 by adding an API to update a user's subjects `seen_ids` list

 Allow a cached user to have their `seen_ids` updated via PUT api endpoints that accepts JSON encoded data payloads:
1. `/api/users/#{user_id}/add_seen_subjects`
    + accepts `{ workflow_id: ${workflow_id}, subject_ids: [1,2,3]}`
0. `/api/users/#{user_id}/add_seen_subject`
    + accepts `{ workflow_id: ${workflow_id}, subject_id: 4}`

The implementation is similar to the existing reliance on the ConCache ETS memory store, i.e the workflow `do_remove` at `/api/workflows/:id/remove` which wrapped the RecentlyRetired ConCache store.

It will raise an error if the workflow_id is not a string or integer that can be cast to an integer. It will check and cast all subject_ids to valid integers before storing in the user cache `seen_ids`. If any subject_id can not be cast it will return a 422 with a message `invalid subject id supplied, must be a valid integer`.

I tried to add better incoming param schema checking but it wasn't nice and added a dep, i left it as it is because it's how it already is combined with the fact it is an internal API and the manta of erlang is fail fast if you are going to fail. If this becomes an issue we can provide better param validation later.

Finally the concache is one big state store shared between tests, i couldn't get the store to reset the cache between tests so came up with a way to reset it manually. Not super happy with it but it works for now.