### PR TITLE
skip training directives for non-logged in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Using Docker:
   docker-compose run --rm test bash
   iex -S mix test --trace
   mix test --only wip
+  # debug wip tests using pry (require IEx IEx.pry)
+  iex -S mix test --only wip
   ```
 
 Running a benchmark:

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -59,12 +59,18 @@ defmodule Designator.Selection do
     |> Designator.Streams.ConfiguredWeights.apply_weights(workflow, user)
     |> Designator.Streams.ConfiguredChances.apply_weights(workflow, user)
 
-    # Finally, these following functions can modify streams in more intricate ways.
-    streams
-    |> Designator.Streams.GoldStandard.apply_weights(workflow, user)
-    |> Designator.Streams.Spacewarps.apply_weights(workflow, user)
-    |> Designator.Streams.PlanetHunters.apply_weights(workflow, user)
-    |> Designator.Streams.Training.apply_weights(workflow, user)
+    case user.user_id do
+      # ignore training directives for non-logged in users
+      nil ->
+        streams
+      _   ->
+        # wire up training directives if we know who the user is
+        streams
+          |> Designator.Streams.GoldStandard.apply_weights(workflow, user)
+          |> Designator.Streams.Spacewarps.apply_weights(workflow, user)
+          |> Designator.Streams.PlanetHunters.apply_weights(workflow, user)
+          |> Designator.Streams.Training.apply_weights(workflow, user)
+    end
   end
 
   defp get_subject_set_from_cache(subject_set_ids, workflow) do


### PR DESCRIPTION
Fixes #87 

Non-logged in users have no seen subjects and thus will always trigger the first tier of training on configured workflows. Instead, this PR will change the behaviour to ignore any training directives for users we have no data on.