### PR TITLE
Use prod env in staging in k8s also

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,8 @@ config :logger, :console,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+# Env vars are loaded via k8s deploy template and secrets, this is unnecessary
+# import_config "#{Mix.env}.exs"
 
 # Configure phoenix generators
 config :phoenix, :generators,

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,8 +31,7 @@ config :logger, :console,
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-# Env vars are loaded via k8s deploy template and secrets, this is unnecessary
-# import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"
 
 # Configure phoenix generators
 config :phoenix, :generators,

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -19,7 +19,7 @@ spec:
           image: zooniverse/designator:__IMAGE_TAG__
           env:
             - name: MIX_ENV
-              value: staging
+              value: prod
             - name: POSTGRES_USER
               value: cellect_ex
             - name: POSTGRES_DB


### PR DESCRIPTION
The pod is failing to start because `** (Code.LoadError) could not load /app/config/staging.exs`. This file doesn't exist on the current staging EC2 instance, either, so I'm not sure what it's supposed to hold. It doesn't exist on S3 and doesn't seem to be being built by any of the designator scripts in the ops repo.

Config options are now being loaded in as env vars via k8s deploy template, but clearly this isn't building without that file loading (presumably the test.exs file for the CI checks). Not sure what's up here yet but I'll have to come back to this later.

