### PR TITLE
Add PORT env var

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -20,6 +20,8 @@ spec:
           env:
             - name: MIX_ENV
               value: prod
+            - name: PORT
+              value: "4000"
             - name: POSTGRES_USER
               value: cellect_ex
             - name: POSTGRES_DB


### PR DESCRIPTION
After merging the last one (https://github.com/zooniverse/designator/pull/93), I started to get yelled at about a missing $PORT env var. This system env var exists on both the prod and staging ec2 instances and is the same on both: `4000`. I can't precisely tell where it's coming from in the current builds but adding it to the template should work.
