### PR TITLE
add root status route with git revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
 FROM elixir:1.8
 
-ENV MIX_ENV prod
-
-ADD . /app
 WORKDIR /app
+
+ADD mix.exs /app
+ADD mix.lock /app
 RUN mix local.hex --force
 RUN mix local.rebar --force
 RUN mix deps.get
+
+ADD . /app
+
+ARG REVISION=''
+ENV REVISION=$REVISION
+
+ENV MIX_ENV prod
+
 RUN mix compile
+
 CMD ["/app/start.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         script {
           def dockerRepoName = 'zooniverse/designator'
           def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
-          def buildArgs = "--build-arg REVISION="${GIT_COMMIT}" ."
+          def buildArgs = "--build-arg REVISION='${GIT_COMMIT}' ."
           def newImage = docker.build(dockerImageName, buildArgs)
 
           if (BRANCH_NAME == 'master') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,11 +10,13 @@ pipeline {
   stages {
     stage('Build Docker image') {
       agent any
+
       steps {
         script {
           def dockerRepoName = 'zooniverse/designator'
           def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
-          def newImage = docker.build(dockerImageName)
+          def buildArgs = "--build-arg REVISION="${GIT_COMMIT}" ."
+          def newImage = docker.build(dockerImageName, buildArgs)
 
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,8 @@ config :designator, Designator.Endpoint,
 config :designator,
   namespace: Designator,
   ecto_repos: [Designator.Repo],
-  reloader: Designator.Reloader.Async
+  reloader: Designator.Reloader.Async,
+  revision: System.get_env("REVISION")
 
 config :designator, :api_auth,
   username: System.get_env("DESIGNATOR_AUTH_USERNAME"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   postgres:
@@ -8,7 +8,8 @@ services:
       - "POSTGRES_PASSWORD=designator"
 
   designator:
-    build: ./
+    build:
+      context: ./
     volumes:
       - ./:/app
       - build_cache:/app/_build

--- a/web/controllers/root_controller.ex
+++ b/web/controllers/root_controller.ex
@@ -1,0 +1,11 @@
+defmodule Designator.RootController do
+  use Designator.Web, :controller
+
+  def index(conn, _params) do
+    status = %{
+      status: :ok,
+      revision: Application.get_env(:designator, :revision)
+    }
+    render conn, "index.json", status: status
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -6,6 +6,12 @@ defmodule Designator.Router do
     plug :accepts, ["json"]
   end
 
+  scope "/", Designator do
+    pipe_through :api
+
+    get "/", RootController, :index
+  end
+
   scope "/api", Designator do
     pipe_through :api
 

--- a/web/views/root_view.ex
+++ b/web/views/root_view.ex
@@ -1,0 +1,7 @@
+defmodule Designator.RootView do
+  use Designator.Web, :view
+
+  def render("index.json", %{status: status}) do
+    status
+  end
+end


### PR DESCRIPTION
add status page on root `/` path with git revision. the git revision will be injected at build time via jenkins, no more git dep in the repo or reading / caching files for this info, it's a straight up env var now 🎉 