### PR TITLE
K8s limits increase RAM & CPU

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -23,7 +23,7 @@ spec:
               cpu: "1000m"
             limits:
               memory: "4000Mi"
-              cpu: "2000m"
+              cpu: "1500m"
           livenessProbe:
             httpGet:
               path: /

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,11 +19,11 @@ spec:
           image: zooniverse/designator:__IMAGE_TAG__
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "50m"
-            limits:
-              memory: "500Mi"
+              memory: "1000Mi"
               cpu: "1000m"
+            limits:
+              memory: "4000Mi"
+              cpu: "2000m"
           env:
             - name: MIX_ENV
               value: prod

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -22,7 +22,7 @@ spec:
               memory: "100Mi"
               cpu: "10m"
             limits:
-              memory: "100Mi"
+              memory: "200Mi"
               cpu: "500m"
           env:
             - name: MIX_ENV


### PR DESCRIPTION
Allow production more RAM / CPU, match the old ec2 instance specs (4GB RAM & 2vcpus) to avoid the OOM errors and pod restarts, via `kubectl describe pod designator-production-app-56d47b487c-5kvb5`
```
State:          Running
      Started:      Tue, 02 Jun 2020 08:06:06 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Mon, 01 Jun 2020 21:14:39 +0100
      Finished:     Tue, 02 Jun 2020 08:06:05 +0100
    Ready:          True
    Restart Count:  8
```
Also allow staging more RAM to avoid OOM errors and pod restarts on this service.