### PR TITLE
K8s readiness probe

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -28,7 +28,12 @@ spec:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 10  
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
           env:
             - name: MIX_ENV
               value: prod

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -29,6 +29,11 @@ spec:
               path: /
               port: 80
             initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
           env:
             - name: MIX_ENV
               value: prod


### PR DESCRIPTION
Add readiness probe that is used for rolling deployment. I locally tested the app boot times on production image and it's <5s. 

>but the existence of the readiness probe in the spec means that the Pod will start without receiving any traffic and only start receiving traffic after the probe starts succeeding. If your Container needs to work on loading large data, configuration files, or migrations during startup, specify a readiness probe.

https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#when-should-you-use-a-readiness-probe

noting that both the live and readiness probes will hit the container ever 10s (default) https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes