### PR TITLE
Modify k8s RAM & CPU limits

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/designator:__IMAGE_TAG__
           resources:
             requests:
-              memory: "1000Mi"
+              memory: "3000Mi"
               cpu: "1000m"
             limits:
-              memory: "4000Mi"
+              memory: "3000Mi"
               cpu: "1500m"
           livenessProbe:
             httpGet:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -23,7 +23,7 @@ spec:
               cpu: "1000m"
             limits:
               memory: "3000Mi"
-              cpu: "1500m"
+              cpu: "2000m"
           livenessProbe:
             httpGet:
               path: /

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -19,7 +19,7 @@ spec:
           image: zooniverse/designator:__IMAGE_TAG__
           resources:
             requests:
-              memory: "100Mi"
+              memory: "200Mi"
               cpu: "10m"
             limits:
               memory: "200Mi"


### PR DESCRIPTION
Request RAM limit up front and allow prod cpu to burst to 2vcpus

prod ram for current normal load is ~500MB, allowing increase up to ~3GB will provide headroom for larger numbers of concurrent user selections. Allowing the CPU to burst to 2vcpus will also add headroom for scaling events.