### PR TITLE
update designator service K8s resources usage

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/designator:__IMAGE_TAG__
           resources:
             requests:
-              memory: "3000Mi"
-              cpu: "1000m"
+              memory: "500Mi"
+              cpu: "100m"
             limits:
-              memory: "3000Mi"
+              memory: "2000Mi"
               cpu: "2000m"
           livenessProbe:
             httpGet:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -19,7 +19,7 @@ spec:
           image: zooniverse/designator:__IMAGE_TAG__
           resources:
             requests:
-              memory: "200Mi"
+              memory: "100Mi"
               cpu: "10m"
             limits:
               memory: "200Mi"


### PR DESCRIPTION
this PR modifies the 
- staging service pod to request less RAM (frees up 100Mi on the node) for other pod scheduling
- production service pod to request a lot less RAM and less CPU (allow it to grow over time)

Currently the pods (measure after ~60days of service) are using much less in the wild.
```
$ kubectl top pod --containers | grep designator
designator-production-app-57f9cfd984-5x5mk                 designator-production-app        11m          269Mi           
designator-staging-app-5b46778788-kfk9q                    designator-staging-app                  1m            86Mi 
``

Freeing up the request RAM means the other pods can schedule and share the node resources.

When a request is made and a pod is scheduled this compute resource request (CPU/RAM) is allocated for the pod and contributes against the available value on each node. Once a node reaches it's total available it won't schedule any other pods due to be at capacity (unavailable) even if the underling pods aren't using these computer resources.