### PR TITLE
Respect workflow.grouped setting when selection by subject_set

### DIFF
--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -48,7 +48,7 @@ defmodule Designator.Selection do
 
   @spec get_streams(WorkflowCache.t, UserCache.t, integer) :: [SubjectSetStream.t]
   def get_streams(workflow, user, subject_set_id) do
-    streams = selection_subject_set_ids(workflow.subject_set_ids, subject_set_id)
+    streams = selection_subject_set_ids(workflow.grouped, workflow.subject_set_ids, subject_set_id)
     |> get_subject_set_from_cache(workflow)
     |> reject_empty_sets
     |> convert_to_streams(workflow)
@@ -123,12 +123,16 @@ defmodule Designator.Selection do
     Stream.reject(stream, fn x -> MapSet.member?(seen_subject_ids, x) end)
   end
 
-  defp selection_subject_set_ids(all_subject_set_ids, subject_set_id) do
-    if Enum.member?(all_subject_set_ids, subject_set_id) do
+  defp selection_subject_set_ids(true, subject_set_ids, subject_set_id) do
+    if Enum.member?(subject_set_ids, subject_set_id) do
       [ subject_set_id ]
     else
       []
     end
+  end
+
+  defp selection_subject_set_ids(_, subject_set_ids, subject_set_id) do
+    subject_set_ids
   end
 
   defp options_with_defaults(options) do

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -74,9 +74,17 @@ defmodule Designator.Selection do
   end
 
   defp get_subject_set_from_cache(subject_set_ids, workflow) do
-    Enum.map(subject_set_ids, fn subject_set_id ->
-      Designator.SubjectSetCache.get({workflow.id, subject_set_id})
-    end)
+    case subject_set_ids do
+      # empty list, i.e. we didn't find the subject_set id linked to this workflow
+      # gaurd against the problem of returning other subject set data
+      # for a workflow as the subject may not make sense in this workflow contexts
+      [] ->
+        [ Designator.SubjectSetCache.get({workflow.id, nil}) ]
+      _   ->
+        Enum.map(subject_set_ids, fn subject_set_id ->
+          Designator.SubjectSetCache.get({workflow.id, subject_set_id})
+        end)
+    end
   end
 
   @spec convert_to_streams([SubjectSetCache.t], Workflow.t) :: [SubjectStream.t]
@@ -119,7 +127,7 @@ defmodule Designator.Selection do
     if Enum.member?(all_subject_set_ids, subject_set_id) do
       [ subject_set_id ]
     else
-      all_subject_set_ids
+      []
     end
   end
 

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -131,7 +131,7 @@ defmodule Designator.Selection do
     end
   end
 
-  defp selection_subject_set_ids(_, subject_set_ids, subject_set_id) do
+  defp selection_subject_set_ids(_, subject_set_ids, _subject_set_id) do
     subject_set_ids
   end
 

--- a/lib/designator/subject_set_cache.ex
+++ b/lib/designator/subject_set_cache.ex
@@ -61,13 +61,13 @@ defmodule Designator.SubjectSetCache do
     ConCache.put(:subject_set_cache, key, subject_set)
   end
 
-  def reload({workflow_id, nil} = key) do
+  def reload({_workflow_id, nil} = key) do
     ConCache.update_existing(:subject_set_cache, key, fn(subject_set) ->
       {:ok, %__MODULE__{subject_set | reloading_since: DateTime.utc_now}}
     end)
   end
 
-  def reload({workflow_id, subject_set_id} = key) do
+  def reload({_workflow_id, _subject_set_id} = key) do
     ConCache.update_existing(:subject_set_cache, key, fn(subject_set) ->
       if subject_set.reloading_since && Timex.after?(subject_set.reloading_since, Timex.shift(Timex.now, hours: -1)) do
         {:error, :already_reloading}

--- a/lib/designator/subject_set_cache.ex
+++ b/lib/designator/subject_set_cache.ex
@@ -61,7 +61,13 @@ defmodule Designator.SubjectSetCache do
     ConCache.put(:subject_set_cache, key, subject_set)
   end
 
-  def reload(key) do
+  def reload({workflow_id, nil} = key) do
+    ConCache.update_existing(:subject_set_cache, key, fn(subject_set) ->
+      {:ok, %__MODULE__{subject_set | reloading_since: DateTime.utc_now}}
+    end)
+  end
+
+  def reload({workflow_id, subject_set_id} = key) do
     ConCache.update_existing(:subject_set_cache, key, fn(subject_set) ->
       if subject_set.reloading_since && Timex.after?(subject_set.reloading_since, Timex.shift(Timex.now, hours: -1)) do
         {:error, :already_reloading}

--- a/lib/designator/workflow_cache.ex
+++ b/lib/designator/workflow_cache.ex
@@ -18,7 +18,7 @@ defmodule Designator.WorkflowCache do
 
   ### Public API
 
-  defstruct [:id, :subject_set_ids, :configuration, :prioritized]
+  defstruct [:id, :subject_set_ids, :configuration, :prioritized, :grouped]
 
   def status do
     :workflow_cache
@@ -61,14 +61,16 @@ defmodule Designator.WorkflowCache do
           id: workflow_id,
           subject_set_ids: [],
           configuration: %{},
-          prioritized: false
+          prioritized: false,
+          grouped: false
         }
       workflow ->
         %__MODULE__{
           id: workflow_id,
           subject_set_ids: Designator.Workflow.subject_set_ids(workflow_id),
           configuration: workflow.configuration,
-          prioritized: workflow.prioritized
+          prioritized: workflow.prioritized,
+          grouped: workflow.grouped
        }
     end
   end

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -101,22 +101,22 @@ defmodule Designator.SelectionTest do
     assert Selection.select(338, 1) == []
   end
 
-  test "selects subjects from a supplied subject_set_id" do
+  test "selects subjects from all subject sets if supplied with a linked subject_set_id" do
     Designator.Random.seed({123, 123534, 345345})
     Designator.WorkflowCache.set(338, %{ configuration: %{}, subject_set_ids: [681, 1706]})
     SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
     SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
 
-    assert Selection.select(338, 1, [subject_set_id: 681, limit: 2]) == [1]
+    assert Selection.select(338, 1, [subject_set_id: 681, limit: 2]) == [2,1]
   end
 
-  test "returns and empty list if selecting from an unknown subject_set_id" do
+  test "selects subjects from all subject sets if an unknown subject_set_id" do
     Designator.Random.seed({123, 123534, 345345})
     Designator.WorkflowCache.set(338, %{ configuration: %{}, subject_set_ids: [681, 1706]})
     SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
     SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
 
-    assert Selection.select(338, 1, [subject_set_id: 1, limit: 2]) == []
+    assert Selection.select(338, 1, [subject_set_id: 1, limit: 2]) == [2,1]
   end
 
   test "does not select recently handed out subject ids" do
@@ -158,5 +158,25 @@ defmodule Designator.SelectionTest do
     SubjectSetCache.set({338, 1681},%SubjectSetCache{workflow_id: 338, subject_set_id: 1003, subject_ids: Array.from_list([4])})
 
     assert Selection.select(338, 1, [limit: 2]) == [4, 3]
+  end
+
+  describe "with grouped workflow" do
+    test "selects subjects from a supplied subject_set_id" do
+      Designator.Random.seed({123, 123534, 345345})
+      Designator.WorkflowCache.set(338, %{ configuration: %{}, grouped: true, subject_set_ids: [681, 1706]})
+      SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
+      SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
+
+      assert Selection.select(338, 1, [subject_set_id: 681, limit: 2]) == [1]
+    end
+
+    test "returns an empty list if selecting from an unknown subject_set_id" do
+      Designator.Random.seed({123, 123534, 345345})
+      Designator.WorkflowCache.set(338, %{ configuration: %{}, grouped: true, subject_set_ids: [681, 1706]})
+      SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
+      SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
+
+      assert Selection.select(338, 1, [subject_set_id: 1, limit: 2]) == []
+    end
   end
 end

--- a/test/designator/selection_test.exs
+++ b/test/designator/selection_test.exs
@@ -110,13 +110,13 @@ defmodule Designator.SelectionTest do
     assert Selection.select(338, 1, [subject_set_id: 681, limit: 2]) == [1]
   end
 
-  test "selects subjects from all subject sets if an unknown subject_set_id" do
+  test "returns and empty list if selecting from an unknown subject_set_id" do
     Designator.Random.seed({123, 123534, 345345})
     Designator.WorkflowCache.set(338, %{ configuration: %{}, subject_set_ids: [681, 1706]})
     SubjectSetCache.set({338, 681},  %SubjectSetCache{workflow_id: 338, subject_set_id: 681, subject_ids: Array.from_list([1])})
     SubjectSetCache.set({338, 1706}, %SubjectSetCache{workflow_id: 338, subject_set_id: 1706, subject_ids: Array.from_list([2])})
 
-    assert Selection.select(338, 1, [subject_set_id: 1, limit: 2]) == [2,1]
+    assert Selection.select(338, 1, [subject_set_id: 1, limit: 2]) == []
   end
 
   test "does not select recently handed out subject ids" do

--- a/test/designator/workflow_cache_test.exs
+++ b/test/designator/workflow_cache_test.exs
@@ -20,6 +20,7 @@ defmodule Designator.WorkflowCacheTest do
     assert WorkflowCache.get(workflow_id_not_in_db) == %Designator.WorkflowCache{
       configuration: %{},
       id: 2,
+      grouped: false,
       prioritized: false,
       subject_set_ids: []
     }

--- a/test/models/workflow_test.exs
+++ b/test/models/workflow_test.exs
@@ -1,6 +1,15 @@
 defmodule Designator.WorkflowTest do
   use Designator.ConnCase
 
+  describe "grouped" do
+    test "loads the grouped attribute" do
+      wf = %Designator.Workflow{id: 1, grouped: true}
+      {:ok, inserted_wf} = Designator.Repo.insert(wf)
+
+      assert Designator.Workflow.find(inserted_wf.id).grouped == true
+    end
+  end
+
   describe "subject_set_ids" do
     test "returns linked subject set ids" do
       Ecto.Adapters.SQL.query!(Designator.Repo, "INSERT INTO workflows (id, created_at, updated_at) VALUES (1, NOW(), NOW())")

--- a/web/models/workflow.ex
+++ b/web/models/workflow.ex
@@ -8,6 +8,7 @@ defmodule Designator.Workflow do
     field :project_id, :integer
     field :configuration, :map
     field :prioritized, :boolean
+    field :grouped, :boolean
 
     timestamps inserted_at: :created_at
   end
@@ -36,7 +37,7 @@ defmodule Designator.Workflow do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:id, :configuration])
+    |> cast(params, [:id, :configuration, :grouped, :prioritized])
   end
 
 end


### PR DESCRIPTION
closes #91 

This PR changes the way per subject set selection works in Designator. Currently we allow filtering on subject sets even if the workflow isn't grouped. 

This PR will now ensure ensure we respect `subject_set_id` param for grouped workflows and do not return data in other linked sets. For non grouped workflows this PR will ignore the `subject_set_id` param and select from all sets which is the current behaviour if the set is not found.

Thus a workflow must have grouped turned on to access per subject_set selection behaviours.