### PR TITLE
use System.stacktrace inside rescue / catch

### DIFF
--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -41,7 +41,7 @@ defmodule Designator.Selection do
           # throw an arbitrary run time error
           raise "the task didn't respond on time"
         rescue
-          exception ->
+          _exception ->
             Rollbax.report(:throw, :selection_timeout, System.stacktrace(),
           %{subject_set_ids: Enum.map(streams, &(&1.subject_set_id)),
             stream_amount: stream_amount,

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -37,10 +37,16 @@ defmodule Designator.Selection do
         Designator.UserCache.add_recently_selected(user, selected_ids)
         selected_ids
       :nil ->
-        Rollbax.report(:throw, :selection_timeout, System.stacktrace(),
+        try do
+          # throw an arbitrary run time error
+          raise "the task didn't respond on time"
+        rescue
+          exception ->
+            Rollbax.report(:throw, :selection_timeout, System.stacktrace(),
           %{subject_set_ids: Enum.map(streams, &(&1.subject_set_id)),
             stream_amount: stream_amount,
             seen_size: seen_size})
+        end
 
         []
     end


### PR DESCRIPTION
avoid deprecated lang features - make sure we can correctly report the stacktrace by throwing an artifical run time error if we hit a task timeout

Reported in https://github.com/zooniverse/designator/pull/121/files
> System.stacktrace/0 outside of rescue/catch clauses is deprecated. If you want to support only Elixir v1.7+, you must access __STACKTRACE__ inside a rescue/catch. If you want to support earlier Elixir versions, move System.stacktrace/0 inside a rescue/catch