### PR TITLE
Fix compiler warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,6 @@ defmodule Designator.Mixfile do
   defp aliases() do
     ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
      "ecto.reset": ["ecto.drop", "ecto.setup"],
-     "test":       ["ecto.create --quiet", "ecto.migrate", "test"]]
+     test:       ["ecto.create --quiet", "ecto.migrate", "test"]]
   end
 end

--- a/test/support/cache_case.ex
+++ b/test/support/cache_case.ex
@@ -23,7 +23,7 @@ defmodule Designator.CacheCase do
     end
   end
 
-  setup tags do
+  setup do
     clear_cache(:workflow_cache)
     clear_cache(:user_cache)
     clear_cache(:subject_set_cache)

--- a/web/models/user_seen_subject.ex
+++ b/web/models/user_seen_subject.ex
@@ -11,7 +11,7 @@ defmodule Designator.UserSeenSubject do
     timestamps inserted_at: :created_at
   end
 
-  def seen_subject_ids(workflow_id, nil), do: []
+  def seen_subject_ids(_workflow_id, nil), do: []
   def seen_subject_ids(workflow_id, user_id) do
     query = from uss in "user_seen_subjects",
       where: uss.workflow_id == ^workflow_id and uss.user_id == ^user_id,


### PR DESCRIPTION
Warnings as outlined in GA actions output and from `mix test`, this PR removes the following
- unused function params
- unused tag context in test setup
- quoted keywords