### PR TITLE
Revert "use v11 to match servers"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:11
+    image: postgres:9.5
     environment:
       - "POSTGRES_USER=designator"
       - "POSTGRES_PASSWORD=designator"


### PR DESCRIPTION
Reverts zooniverse/designator#130

Sadly our version of the DB connection `postgrex` can't work with the higher PG server version - we need to upgrade but can't due to depdency conflicts with the phoenix framework. Punting this for future selves to upgrade phoenix and it only impacts dev envs not production (`mix ecto.create` etc)