### PR TITLE
add user_id and workflow_id to error report

### DIFF
--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -45,7 +45,9 @@ defmodule Designator.Selection do
             Rollbax.report(:throw, :selection_timeout, System.stacktrace(),
           %{subject_set_ids: Enum.map(streams, &(&1.subject_set_id)),
             stream_amount: stream_amount,
-            seen_size: seen_size})
+            seen_size: seen_size,
+            user_id: user.user_id,
+            workflow_id: workflow.id})
         end
 
         []


### PR DESCRIPTION
allow more insight into which user / workflows are hitting the timeouts