### PR TITLE
Skip recent seen filtering for priority workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Using Docker:
   # run the tests
   mix test
   iex -S mix test --trace
+  # run WIP tests (add the @tag :wip to the test(s) in question)
   mix test --only wip
 
   # debug wip tests using pry (require IEx IEx.pry)

--- a/lib/designator/selection.ex
+++ b/lib/designator/selection.ex
@@ -27,7 +27,7 @@ defmodule Designator.Selection do
       |> Designator.StreamTools.interleave
       |> deduplicate
       |> reject_recently_retired(workflow)
-      |> reject_recently_selected(user)
+      |> reject_recently_selected(user, workflow.prioritized)
       |> reject_seen_subjects(seen_subject_ids)
       |> Enum.take(amount)
     end)
@@ -123,7 +123,11 @@ defmodule Designator.Selection do
     Stream.reject(stream, fn id -> MapSet.member?(subject_ids, id) end)
   end
 
-  defp reject_recently_selected(stream, user) do
+  defp reject_recently_selected(stream, user, true) do
+    stream
+  end
+
+  defp reject_recently_selected(stream, user, _) do
     Stream.reject(stream, fn x -> MapSet.member?(user.recently_selected_ids, x) end)
   end
 


### PR DESCRIPTION
closes https://github.com/zooniverse/panoptes/issues/3789

avoid skipping past what has been recently seen in the user cache as priority workflows want to ensure folks see the head of the priority queue in order at all times.