### PR TITLE
Deploy staging with an Action

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,42 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build_and_push_image:
+    name: Build and Push Image
+    uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
+    with:
+      repo_name: designator
+      commit_id: ${{ github.sha }}
+      latest: true
+
+  deploy_staging:
+    name: Deploy to Staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_app.yaml@main
+    needs: build_and_push_image
+    with:
+      app_name: designator
+      repo_name: designator
+      commit_id: ${{ github.sha }}
+      environment: staging
+    secrets:
+      creds: ${{ secrets.AZURE_AKS }}
+
+  deploy_slack_notification:
+    name: Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy_staging
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Deploy to Staging / deploy_app
+      status: ${{ needs.deploy_staging.result }}
+      title: "Designator Staging migration & deploy complete"
+      title_link: "https://designator-staging.zooniverse.org/"
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,14 +35,6 @@ pipeline {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl --context azure apply --record -f -"
       }
     }
-
-    stage('Deploy staging to Kubernetes') {
-      when { branch 'master' }
-      agent any
-      steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
-      }
-    }
   }
 
   post {


### PR DESCRIPTION
Builds/pushes a new image to GHCR, tags with latest, and deploys to staging. Does not perform any migration, does this happen automatically anywhere now? We obviously haven't had to do one in a while (see also eduapi & caesar) but there's no Jenkins job or hook and it seems like it'd have to be manual from a pod. I can build a k8s job to run whatever the appropriate `mix` command is if that'd be useful.