### PR TITLE
Use commit_id.txt for revision & keep env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN mix deps.get
 
 ADD . /app
 
-ARG REVISION=''
+# Check for a commit_id.txt file: if missing, use default
+RUN export COMMIT_ID=$(cat commit_id.txt)
+RUN REVISION="${COMMIT_ID:-asdf123jkl456}"
 ENV REVISION=$REVISION
 
 ENV MIX_ENV prod


### PR DESCRIPTION
Designator's RootController pulls the revision out of the system's env vars. This sets that env var in the Dockerfile from the commit_id.txt file that the build/push action creates. It sets a default if the file is missing, so that the file isn't required for development.