### PR TITLE
Set $REVISION in start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN mix deps.get
 
 ADD . /app
 
-ARG REVISION=''
+# Check for a commit_id.txt file: if missing, use default
+RUN export COMMIT_ID=$(cat commit_id.txt)
+RUN REVISION="${COMMIT_ID:-asdf123jkl456}"
 ENV REVISION=$REVISION
 
 ENV MIX_ENV prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,6 @@ RUN mix deps.get
 
 ADD . /app
 
-# Check for a commit_id.txt file: if missing, use default
-RUN export COMMIT_ID=$(cat commit_id.txt)
-RUN REVISION="${COMMIT_ID:-asdf123jkl456}"
-ENV REVISION=$REVISION
-
 ENV MIX_ENV prod
 
 RUN mix compile

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# set REVISION env var from commit_id.txt or default
+COMMIT_ID=$(cat commit_id.txt 2> /dev/null)
+REVISION="${COMMIT_ID:-asdf123jkl456}"
+
 # ensure we stop on error (-e) and log cmds (-x)
 set -ex
 ERLANG_NODE_NAME=${ERLANG_NODE_NAME:-erlang@designator.zooniverse.org}


### PR DESCRIPTION
Reading from a file and conditionally setting different env vars isn't ideal for a Dockerfile, since the env vars from RUN commands aren't persisted across layers. Instead, just run a couple lines in the start script to read from the file and set a default if it's missing.